### PR TITLE
Documentation and README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Flow
 
-Flow is a computational framework for deep RL and control experiments for traffic microsimulation.
+[Flow](https://berkeleyflow.github.io) is a computational framework for deep RL and control experiments for traffic microsimulation.
 
 See [our website](https://berkeleyflow.github.io) for more information on the application of Flow to several mixed-autonomy traffic scenarios. Other [results and videos](https://sites.google.com/view/ieee-tro-flow/home) are available as well.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Flow is a computational framework for deep RL and control experiments for traffic microsimulation.
 
-See [results and videos](https://sites.google.com/view/ieee-tro-flow/home) of the application of Flow to several mixed-autonomy traffic scenarios.
+See [our website](https://berkeleyflow.github.io) for more information on the application of Flow to several mixed-autonomy traffic scenarios. Other [results and videos](https://sites.google.com/view/ieee-tro-flow/home) are available as well.
 
 # More information
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-autodoc_mock_imports = ["traci"]
+autodoc_mock_imports = ["traci", 'sumolib']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-autodoc_mock_imports = ["traci", "sumolib"]
+autodoc_mock_imports = ["traci"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-autodoc_mock_imports = ["traci"]
+autodoc_mock_imports = ["traci", "sumolib"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
         return MagicMock()
 
-MOCK_MODULES = ['traci', 'sumolib']
+MOCK_MODULES = ['traci', 'traci.constants', 'sumolib']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,17 +37,7 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-# autodoc_mock_imports = ["traci"]
-from unittest.mock import MagicMock
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return MagicMock()
-
-MOCK_MODULES = ['traci', 'traci.constants']
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
-
+autodoc_mock_imports = ["traci"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-# autodoc_mock_imports = ["traci", 'sumolib']
+autodoc_mock_imports = ["traci"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-# autodoc_mock_imports = ["traci"]
+autodoc_mock_imports = ["traci"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-autodoc_mock_imports = ["traci", 'sumolib']
+# autodoc_mock_imports = ["traci", 'sumolib']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,8 @@ napoleon_use_ivar = True
 
 autodoc_mock_imports = ["traci"]
 
+add_module_names = False
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,8 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
+autodoc_mock_imports = ["traci", "ray", "rllab"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ napoleon_use_ivar = True
 # mock imports for sumolib (another module that errors) leads to build failures
 # entirely.
 
-# autodoc_mock_imports = ["traci"]
+autodoc_mock_imports = ["traci"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ class Mock(MagicMock):
     def __getattr__(cls, name):
         return MagicMock()
 
-MOCK_MODULES = ['traci', 'traci.constants', 'sumolib']
+MOCK_MODULES = ['traci', 'traci.constants']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-autodoc_mock_imports = ["traci"]
+# autodoc_mock_imports = ["traci"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,17 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-autodoc_mock_imports = ["traci"]
+# autodoc_mock_imports = ["traci"]
+from unittest.mock import MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return MagicMock()
+
+MOCK_MODULES = ['traci', 'sumolib']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-autodoc_mock_imports = ["traci", "ray", "rllab"]
+autodoc_mock_imports = ["traci"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,9 +37,13 @@ napoleon_google_docstring = False
 napoleon_use_param = False
 napoleon_use_ivar = True
 
-autodoc_mock_imports = ["traci"]
+# This prevents some errors during the autodoc building process, since
+# errors occur when importing traci and sumolib. A mock import for traci
+# enables some more autodocs to be built, as flow.core.vehicles, but
+# mock imports for sumolib (another module that errors) leads to build failures
+# entirely.
 
-add_module_names = False
+# autodoc_mock_imports = ["traci"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/flow_setup.rst
+++ b/docs/source/flow_setup.rst
@@ -2,8 +2,11 @@ Setup Instructions
 ******************
 
 To get Flow running, you need three things: Flow,
-SUMO, and a reinforcement learning library (RLlib/rllab). Once each 
-component is installed successfully, you might get some missing 
+SUMO, and (optionally) a reinforcement learning library (RLlib/rllab). 
+If you choose not to install a reinforcement learning library, you will 
+still be able to build and run SUMO-only traffic tasks, but will not be 
+able to run experiments which require learning agents. Once
+each component is installed successfully, you might get some missing
 module bugs from Python. Just install the missing module using 
 your OS-specific package manager / installation tool. Follow the 
 shell commands below to get started.
@@ -11,8 +14,9 @@ shell commands below to get started.
 Dependencies
 ============
 We begin by installing dependencies needed by the four repositories mentioned
-above.
-It will be useful to install `Anaconda <https://www.anaconda.com/download>`_ for Python and enable it right away.
+above. It will be useful to install `Anaconda <https://www.anaconda.com/download>`_
+for Python and enable it right away.
+
 For Ubuntu 16.04:
 ::
 
@@ -20,7 +24,8 @@ For Ubuntu 16.04:
     sudo apt-get install cmake swig libgtest-dev python-pygame python-scipy autoconf libtool pkg-config libgdal-dev libxerces-c-dev libproj-dev libfox-1.6-dev libxml2-dev libxslt1-dev build-essential curl unzip flex bison python python-dev python3-dev
     sudo pip3 install cmake cython
 
-For OSX:
+For OSX (feel free to ignore the rllab dependencies if you don't wish to
+install it):
 ::
 
     # rllab dependencies
@@ -37,7 +42,7 @@ human-driven agents during the simulation process.
 
     cd ~
     git clone https://github.com/DLR-TS/sumo.git
-    cd sumo 
+    cd sumo
     git checkout 1d4338ab80
     make -f Makefile.cvs
     export CPPFLAGS=-I/opt/X11/include
@@ -49,11 +54,53 @@ human-driven agents during the simulation process.
     echo 'export PYTHONPATH="$HOME/sumo/tools:$PYTHONPATH"' >> ~/.bashrc
     source ~/.bashrc
 
-rllab-multiagent
-================
+Flow
+====
+Once sumo and the various dependencies are in place, we are ready to install a
+functional version of Flow. With this, we can begin to simulate traffic within
+sumo using OpenAI gym-compatible environments. Note that separate RL algorithms
+will be needed to train autonomous agents within the simulation to improve
+various traffic flow properties (see the sections on rllab-multiagent and
+Ray/RLlib for more).
+::
+
+    cd ~
+    git clone https://github.com/berkeleyflow/flow.git
+    cd flow
+    python3 setup.py develop
+    echo 'export PYTHONPATH="$HOME/flow:$PYTHONPATH"' >> ~/.bashrc
+    source ~/.bashrc
+
+
+Testing the Installation
+========================
+
+Once the above modules have been successfully installed, we can test the
+installation by running a few examples.
+
+Let’s see some traffic action:
+::
+
+    python examples/sumo/sugiyama.py
+
+Running the following should result in the loading of the SUMO GUI.
+Click the run button and you should see unstable traffic form after a
+few seconds, a la (Sugiyama et al, 2008). This means that you have Flow
+properly configured with SUMO.
+
+Optionally, run the unit tests:
+::
+
+    nose2 -s tests/fast_tests
+
+Congratulations, you now have successfully set up Flow!
+
+
+rllab-multiagent (optional)
+===========================
 Flow has been tested on a variety of RL libraries, the installation of which is
 optional but may be of use when trying to execute some of the examples files
-located in Flow. rllab-multiagent is one of these such libraries.  In order 
+located in Flow. rllab-multiagent is one of these such libraries.  In order
 to install the `rllab-multiagent` library, follow the below instructions
 ::
 
@@ -64,19 +111,9 @@ to install the `rllab-multiagent` library, follow the below instructions
     python3 setup.py develop
     echo 'export PYTHONPATH="$HOME/rllab-multiagent:$PYTHONPATH"' >> ~/.bashrc
     source ~/.bashrc
-    ```
 
-    ## flow
-    ```shell
-    cd ~/rllab-multiagent # Repo flow needs to be installed within rllab-multiagent.
-    git clone https://github.com/berkeleyflow/flow.git
-    cd flow
-    python3 setup.py develop
-    echo 'export PYTHONPATH="$HOME/rllab-multiagent/flow:$PYTHONPATH"' >> ~/.bashrc
-    source ~/.bashrc
-
-Ray/RLlib
-=========
+Ray/RLlib (optional)
+====================
 RLlib is another RL library that has been extensively tested on the Flow
 repository. The installation process for this library is as follows:
 ::
@@ -87,46 +124,40 @@ repository. The installation process for this library is as follows:
     sudo python3 setup.py develop
     popd
 
-If missing libraries cause errors, please also install the required libraries as specified at <http://ray.readthedocs.io/en/latest/installation.html> and then follow the setup instructions.
+If missing libraries cause errors, please also install the required libraries
+as specified at <http://ray.readthedocs.io/en/latest/installation.html> and
+then follow the setup instructions.
 
-Testing the Installation
-========================
-
-Once the above modules have been successfully installed, we can test the
-installation by running a few examples.
+Getting started (rllab-multiagent)
+==================================
 
 To run any of the RL examples, make sure to run
 ::
 
     source activate flow
     
-Running the following should result in the loading of the SUMO GUI.
-Click the run button and you should see unstable traffic form after a
-few seconds, a la (Sugiyama et al, 2008).
-
-Run the unit tests:
+In order to test run an Flow experiment in rllab-multiagent, try the following
+command:
 ::
 
-    nose2 -s tests/fast_tests
+    python examples/rllab/stabilizing_the_ring.py
 
-Let’s see some traffic action:
-::
-
-    python examples/sumo/sugiyama.py
-
-This means that you have Flow properly configured with SUMO.
-::
-
-    python examples/rllib/stabilizing_the_ring.py
-
-This means that you have Flow properly configured with both SUMO and
-rllib. Congratulations, you now have Flow set up!
+If it does not fail, this means that you have Flow properly configured with
+rllab-multiagent.
 
 
 Getting started (Ray/RLlib)
 ===========================
 
 See `getting started with RLlib <http://ray.readthedocs.io/en/latest/rllib.html#getting-started>`_ for sample commands.
+
+In order to test run an Flow experiment in RLlib, try the following command:
+::
+
+    python examples/rllab/stabilizing_the_ring.py
+
+If it does not fail, this means that you have Flow properly configured with
+RLlib.
 
 To visualize the training progress:
 ::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,9 +18,9 @@ Tutorials `are available <https://github.com/berkeleyflow/flow/tree/master/tutor
 
    intro
    flow_setup
+   Tutorials <https://github.com/berkeleyflow/flow/tree/master/tutorials/>
    visualizing
    modules
-   Tutorials <https://github.com/berkeleyflow/flow/tree/master/tutorials/>
 
 
 .. Citing Flow

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Welcome to Flow
 `Flow <https://berkeleyflow.github.io>`_ is a computational framework for deep RL and control experiments for traffic microsimulation. Visit `our website <https://berkeleyflow.github.io>`_ for more information. 
 
 Flow is a work in progress - input is welcome. Available documentation is limited for now. 
-Tutorials `are available <https://github.com/berkeleyflow/flow/tree/master/tutorials/exercises>`_ in iPython notebook format.
+`Tutorials <https://github.com/berkeleyflow/flow/tree/master/tutorials/exercises>`_ are available in iPython notebook format.
 
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@ Tutorials `are available <https://github.com/berkeleyflow/flow/tree/master/tutor
    flow_setup
    visualizing
    modules
-
+   Tutorials <https://github.com/berkeleyflow/flow/tree/master/tutorials/>
 
 
 .. Citing Flow

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,7 @@
 Welcome to Flow
 ================
 
-Flow is a computational framework for deep RL and control experiments for traffic microsimulation.
+`Flow <https://berkeleyflow.github.io>`_ is a computational framework for deep RL and control experiments for traffic microsimulation. Visit `our website <https://berkeleyflow.github.io>`_ for more information. 
 
 Flow is a work in progress - input is welcome. Available documentation is limited for now. 
 Tutorials `are available <https://github.com/berkeleyflow/flow/tree/master/tutorials/exercises>`_ in iPython notebook format.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,7 @@ Welcome to Flow
 Flow is a computational framework for deep RL and control experiments for traffic microsimulation.
 
 Flow is a work in progress - input is welcome. Available documentation is limited for now. 
-Tutorials in iPython notebook format are available through `our GitHub <https://github.com/berkeleyflow/flow/tree/master/tutorials/exercises>`_.
+Tutorials `are available <https://github.com/berkeleyflow/flow/tree/master/tutorials/exercises>`_ in iPython notebook format.
 
 
 .. toctree::

--- a/flow/scenarios/bottleneck/__init__.py
+++ b/flow/scenarios/bottleneck/__init__.py
@@ -1,1 +1,0 @@
-# empty init file to ensure documentation for benchmarks is created

--- a/flow/scenarios/bottleneck/__init__.py
+++ b/flow/scenarios/bottleneck/__init__.py
@@ -1,0 +1,1 @@
+# empty init file to ensure documentation for benchmarks is created


### PR DESCRIPTION
Modified the homepage of the documentation to point to the tutorials with more emphasis. I also added a comment in `conf.py` that would enable a mock import for traci, which helps but doesn't fully resolve our autodoc issues. (I'll add a full PR for autodocs with I figure them out).  Resolves https://github.com/berkeleyflow/flow-devel/issues/76.